### PR TITLE
logoutBtn href is changed to /signup

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -59,7 +59,7 @@
             <a
               id="logoutBtn"
               class="dropdown-item text-light"
-              href="/logout"
+              href="/signup"
             >Log out</a>
           </div>
         </div>
@@ -73,7 +73,7 @@
 
     <!-- Render script for logged in users only -->
     {{#if logged_in}}
-      <script src="/js/logout.js"></script>
+      <script src="/js/main.js"></script>
     {{/if}}
 
     <div>


### PR DESCRIPTION
logoutBtn error is fixed by changing its href to "/signup."